### PR TITLE
Various fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,14 +21,14 @@ GEM
       deep_merge
     fakefs (0.18.0)
     gli (2.18.0)
-    jaro_winkler (1.5.1)
+    jaro_winkler (1.5.2)
     json (2.1.0)
-    method_source (0.9.0)
+    method_source (0.9.2)
     parallel (1.12.1)
-    parser (2.5.1.2)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
-    pry (0.11.3)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rainbow (3.0.0)
@@ -39,7 +39,7 @@ GEM
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.1)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.0)
@@ -47,16 +47,16 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     rsync (1.0.9)
-    rubocop (0.59.2)
+    rubocop (0.62.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.30.0)
-      rubocop (>= 0.58.0)
+      unicode-display_width (~> 1.4.0)
+    rubocop-rspec (1.31.0)
+      rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -65,7 +65,7 @@ GEM
     simplecov-html (0.10.2)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.4.1)
 
 PLATFORMS
   ruby
@@ -82,4 +82,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/lib/moku/artifact.rb
+++ b/lib/moku/artifact.rb
@@ -49,13 +49,15 @@ module Moku
     def_delegators :@signature, :source, :shared, :unshared
 
     def run(command)
-      runner.run("#{env} #{command}")
+      with_env do
+        runner.run("#{env} #{command}")
+      end
     end
 
     def gem_version
       return @gem_version if @gem_version
 
-      major, minor, = runner.run("rbenv local").output.strip.split(".")
+      major, minor, = run("rbenv local").output.strip.split(".")
       @gem_version = "#{major}.#{minor}.0"
     end
 

--- a/lib/moku/artifact.rb
+++ b/lib/moku/artifact.rb
@@ -48,12 +48,17 @@ module Moku
     #   @return [ArchiveReference]
     def_delegators :@signature, :source, :shared, :unshared
 
+    # Run the given command in the context of the artifact.
+    # @return [Status]
     def run(command)
       with_env do
-        runner.run("#{env} #{command}")
+        runner.run("#{rbenv_env} #{command}")
       end
     end
 
+    # Get the gem version of the artifact's source, as specified by rbenv
+    # and as recognized by bundler's installation paths.
+    # @return [String]
     def gem_version
       return @gem_version if @gem_version
 
@@ -61,6 +66,8 @@ module Moku
       @gem_version = "#{major}.#{minor}.0"
     end
 
+    # The path where gems are installed; created if it doesn't exist.
+    # @return [Pathname]
     def bundle_path
       @bundle_path ||= (path/"vendor"/"bundle"/"ruby"/gem_version)
         .tap(&:mkpath)
@@ -68,7 +75,9 @@ module Moku
 
     private
 
-    def env
+    # Environment manipulation necessary to adopt the rbenv version of the
+    # source to be installed.
+    def rbenv_env
       "PATH=$RBENV_ROOT/versions/$(rbenv local)/bin:$PATH"
     end
 

--- a/lib/moku/cached_bundle.rb
+++ b/lib/moku/cached_bundle.rb
@@ -21,14 +21,12 @@ module Moku
     # @param artifact [Artifact]
     # @return [Status]
     def install(artifact)
-      artifact.with_env do
-        Sequence.for([
-          "rsync -r #{cache_path(artifact)}/. #{artifact.bundle_path}/",
-          "bundle install --deployment '--without=development test'",
-          "rsync -r #{artifact.bundle_path}/. #{cache_path(artifact)}/",
-          "bundle clean"
-        ]) {|command| artifact.run(command) }
-      end
+      Sequence.for([
+        "rsync -r #{cache_path(artifact)}/. #{artifact.bundle_path}/",
+        "bundle install --deployment '--without=development test'",
+        "rsync -r #{artifact.bundle_path}/. #{cache_path(artifact)}/",
+        "bundle clean"
+      ]) {|command| artifact.run(command) }
     end
 
     private

--- a/lib/moku/filesystem.rb
+++ b/lib/moku/filesystem.rb
@@ -82,6 +82,8 @@ module Moku
     # @param [Pathname] path
     def rm_empty_tree(path)
       raise ArgumentError, "path cannot be a non-directory file" if path.file?
+      return unless path.exist?
+      return unless path.empty?
 
       FileUtils.rmdir path, parents: true
     end

--- a/lib/moku/release.rb
+++ b/lib/moku/release.rb
@@ -51,6 +51,20 @@ module Moku
 
     attr_reader :artifact, :deploy_config, :remote_runner, :user
 
+    # Environment manipulation necessary to adopt the rbenv version of the
+    # source to be installed. This only has an effect in the test environment
+    # and development enviroments.
+    def rbenv_env
+      "PATH=$RBENV_ROOT/versions/$(rbenv local)/bin:$PATH"
+    end
+
+    def contextualize(command)
+      "if [ -d #{deploy_path} ]; " \
+        "then cd #{deploy_path}; " \
+        "fi; " \
+        "#{rbenv_env} #{deploy_config.shell_env} #{command}"
+    end
+
     def run_on_hosts(hosts, command)
       Sequence.for(hosts) do |host|
         remote_runner.run(
@@ -59,13 +73,6 @@ module Moku
           command: contextualize(command)
         )
       end
-    end
-
-    def contextualize(command)
-      "if [ -d #{deploy_path} ]; " \
-        "then cd #{deploy_path}; " \
-        "fi; " \
-        "#{deploy_config.shell_env} #{command}"
     end
 
   end

--- a/lib/moku/task/shell.rb
+++ b/lib/moku/task/shell.rb
@@ -5,16 +5,15 @@ require "moku/task/task"
 module Moku
   module Task
 
-    # A simple shell task, resolved in the context of the target.
+    # A simple shell task, resolved in the context of the artifact.
     class Shell < Task
 
       def self.from_spec(task_spec)
         new(command: task_spec.command)
       end
 
-      def initialize(command:, runner: Moku.system_runner)
+      def initialize(command:)
         @command = command
-        @runner = runner
       end
 
       def to_s
@@ -23,16 +22,11 @@ module Moku
 
       attr_reader :command
 
-      # @param target [Artifact,Release]
-      def call(target)
-        target.with_env do
-          runner.run(command)
-        end
+      # @param artifact [Artifact]
+      def call(artifact)
+        artifact.run(command)
       end
 
-      private
-
-      attr_reader :runner
     end
 
   end

--- a/spec/cached_bundle_spec.rb
+++ b/spec/cached_bundle_spec.rb
@@ -17,7 +17,6 @@ module Moku
 
     before(:each) do
       FileUtils.mkdir_p path.to_s
-      allow(artifact).to receive(:with_env).and_yield
       allow(artifact).to receive(:gem_version).and_return(version)
       allow(artifact).to receive(:bundle_path).and_return(bundle_path)
       allow(artifact).to receive(:run).and_return(status)
@@ -25,11 +24,6 @@ module Moku
 
     it "runs the bundle command" do
       expect(artifact).to receive(:run).with(/bundle install/)
-      cached_bundle.install(artifact)
-    end
-
-    it "uses the target's bundle context" do
-      expect(artifact).to receive(:with_env)
       cached_bundle.install(artifact)
     end
 

--- a/spec/task/shell_spec.rb
+++ b/spec/task/shell_spec.rb
@@ -9,12 +9,11 @@ require "fakefs/spec_helpers"
 module Moku
   RSpec.describe Task::Shell do
     include FakeFS::SpecHelpers
-    let(:runner) { double(:runner, run: status) }
     let(:path) { Pathname.new("/some/path") }
-    let(:artifact) { double(:artifact, path: path) }
+    let(:artifact) { double(:artifact, path: path, run: status) }
     let(:status) { double(:status, success?: true, error: "") }
     let(:command) { "some command -f -a - p" }
-    let(:task) { described_class.new(command: command, runner: runner) }
+    let(:task) { described_class.new(command: command) }
 
     before(:each) do
       FileUtils.mkdir_p path.to_s
@@ -23,12 +22,7 @@ module Moku
 
     describe "#call" do
       it "runs the command" do
-        expect(runner).to receive(:run).with(command)
-        task.call(artifact)
-      end
-
-      it "uses the target's bundle context" do
-        expect(artifact).to receive(:with_env)
+        expect(artifact).to receive(:run).with(command)
         task.call(artifact)
       end
 


### PR DESCRIPTION
* Resolves remaining issues with running under ruby 2.5
* Fixed an issue where unused gems from a different ruby version were being added to the artifact.
* Set Task::Shell to run in the context of the artifact via `#run` instead of `#with_env`, removing the need for its own runner.
* Set CachedBundle to run in the context of the artifact via `#run` instead of `#with_env`, removing the need for its own runner.
* Fixed an issue where remote tasks failed in test because we didn't set rbenv version, and could not rely on the remote host to set it for us.
* Also fixes the super weird travis issue,  via the bundle update.