### PR TITLE
AEIM-577: Treat rollbacks as releases

### DIFF
--- a/lib/moku/command/rollback.rb
+++ b/lib/moku/command/rollback.rb
@@ -14,7 +14,7 @@ module Moku
       end
 
       def action
-        :deploy
+        :rollback
       end
 
       def cache
@@ -24,6 +24,10 @@ module Moku
           instance.caches.first
         end
       end
+
+      private
+
+      attr_reader :cache_id
     end
 
   end

--- a/lib/moku/instance.rb
+++ b/lib/moku/instance.rb
@@ -55,11 +55,13 @@ module Moku
       @releases << release
     end
 
+    # @return [Array<LoggedRelease>]
     def caches
       releases
         .slice(0, 5)
     end
 
+    # @return [Array<LoggedRelease>]
     def releases
       @releases
         .sort_by(&:id)

--- a/lib/moku/logged_releases.rb
+++ b/lib/moku/logged_releases.rb
@@ -48,7 +48,7 @@ module Moku
         [
           hash[:id],
           hash[:user],
-          hash[:version].slice(0, 11),
+          hash[:version].sub("rollback ", "").slice(0, 11),
           hash[:source].slice(0, 7),
           hash[:deploy].slice(0, 7),
           hash[:unshared].slice(0, 7),

--- a/lib/moku/pipeline/rollback.rb
+++ b/lib/moku/pipeline/rollback.rb
@@ -15,6 +15,7 @@ module Moku
         step :retrieve_signature
         step :construct_release
         step :set_current
+        step :log_release
       end
 
       private
@@ -34,6 +35,17 @@ module Moku
 
       def set_current
         Task::SetCurrent.new.call(release)
+      end
+
+      def log_release
+        instance.log_release(LoggedRelease.new(
+          id: release.id,
+          user: user,
+          time: Time.now,
+          signature: signature,
+          version: "rollback -> #{command.cache.id}"
+        ))
+        Moku.instance_repo.save_releases(instance)
       end
     end
 

--- a/spec/integration/deploy_spec.rb
+++ b/spec/integration/deploy_spec.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
-require_relative "spec_helper"
-require_relative "support/fake_remote_runner"
-require_relative "support/with_a_sandbox"
-require_relative "support/with_a_deployed_instance"
-require_relative "support/a_successful_deploy"
-require_relative "support/with_context"
+require_relative "../spec_helper"
+require_relative "../support/fake_remote_runner"
+require_relative "../support/with_a_sandbox"
+require_relative "../support/with_a_deployed_instance"
+require_relative "../support/a_successful_deploy"
+require_relative "../support/with_context"
 require "open3"
+require "pathname"
 
 module Moku
 
-  RSpec.describe "integration tests", integration: true do
+  RSpec.describe "deploy integration", integration: true do
     describe "deploy" do
       context "without rails" do
         include_context "with a sandbox", "test-norails"

--- a/spec/integration/releases_spec.rb
+++ b/spec/integration/releases_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+require_relative "../support/with_a_sandbox"
+require_relative "../support/with_a_deployed_instance"
+require "moku/command/releases"
+require "moku/command/rollback"
+
+module Moku
+
+  RSpec.describe "releases integration", integration: true do
+    include_context "with a sandbox", "test-norails"
+    include_context "with a deployed instance", "test-norails"
+    include_context "with a deployed instance", "test-norails"
+    before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+      Moku.invoker.add_command(
+        Command::Rollback.new(
+          user: ENV["USER"],
+          instance_name: "test-norails"
+        )
+      )
+    end
+
+    before(:each) do
+      allow(Moku.logger).to receive(:info).and_call_original
+    end
+
+    def get_releases(long:)
+      Moku.invoker.add_command(
+        Command::Releases.new(
+          user: ENV["USER"],
+          instance_name: "test-norails",
+          long: long
+        )
+      )
+    end
+
+    context "with long releases output" do
+      it "displays rollbacks in the list of releases" do
+        expect(Moku.logger).to receive(:info) do |string|
+          recent = string.split("\n")[3]
+          expect(recent).to match(/\| rollback -> #{Time.now.strftime("%Y%m%d")}/)
+        end
+        get_releases(long: true)
+      end
+    end
+
+    context "with short releases output" do
+      let(:long) { false }
+
+      it "displays rollbacks in the list of releases" do
+        expect(Moku.logger).to receive(:info) do |string|
+          recent = string.split("\n")[3]
+          expect(recent).to match(/\| -> #{Time.now.strftime("%Y%m%d")}/)
+        end
+        get_releases(long: false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves AEIM-577

Now that the groundwork is in place this ended up being quite simple. The tests could be more specific but I wanted to avoid brittleness as much as was possible.