### PR TITLE
Add caching of artifacts and avoid building artifacts in /tmp

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,7 @@ instance_root: data/instances
 bundle_cache_path: data/bundle_cache
 releases_root: releases
 deployer_env_root: deploy/capfiles
+build_root: data/cache/builds
 ref_root: data/cache/references
 split_token: 1239810_moku_split_token_678303
 shared_name: infrastructure
@@ -13,3 +14,4 @@ finish_deploy_filename: finish_deploy.yml
 deploy_config_filename: deploy.yml
 release_time_format: "%Y%m%d%H%M%S%L"
 ref_cache_max: 10
+build_cache_max: 20

--- a/lib/moku.rb
+++ b/lib/moku.rb
@@ -3,6 +3,7 @@
 require "moku/version"
 require "moku/archive_reference"
 require "moku/artifact"
+require "moku/artifact_repo"
 require "moku/auth_service"
 require "moku/cached_bundle"
 require "moku/cli"
@@ -54,6 +55,7 @@ module Moku
             filesystem: c.filesystem
           )
         end
+        container.register(:artifact_repo) {|c| Moku::ArtifactRepo.new(c.build_root) }
         container.register(:ref_repo) do |c|
           Moku::ReferenceRepo.new(
             c.ref_root,
@@ -89,20 +91,17 @@ module Moku
         end
 
         container.register(:invoker) { Moku::Invoker.new }
-        container.register(:instance_root) do
-          Pathname.new(settings.instance_root).expand_path(Moku.root)
-        end
-        container.register(:releases_root) do
-          Pathname.new(settings.releases_root).expand_path(Moku.root)
-        end
-        container.register(:deployer_env_root) do
-          Pathname.new(settings.deployer_env_root).expand_path(Moku.root)
-        end
-        container.register(:ref_root) do
-          Pathname.new(settings.ref_root).expand_path(Moku.root)
-        end
-        container.register(:branches_root) do
-          Pathname.new(settings.branches_root).expand_path(Moku.root)
+        [
+          :instance_root,
+          :releases_root,
+          :deployer_env_root,
+          :ref_root,
+          :branches_root,
+          :build_root
+        ].each do |root|
+          container.register(root) do
+            Pathname.new(settings.public_send(root)).expand_path(Moku.root)
+          end
         end
       end
     end

--- a/lib/moku/artifact_repo.rb
+++ b/lib/moku/artifact_repo.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "moku/artifact"
+require "pathname"
+require "fileutils"
+
+module Moku
+
+  # Repository for built artifacts
+  class ArtifactRepo
+
+    # @param dir [Pathname] A directory in which to store artifacts
+    def initialize(dir, max_cache: Moku.build_cache_max)
+      @dir = Pathname.new(dir).tap(&:mkpath)
+      @max_cache = (max_cache - 1) || 1
+      # -1 because we prune before building, so we won't reach it until max + 1.
+    end
+
+    # Obtain the build for the given instance and signature, and build
+    # it using the given plan if it is not already built.
+    # This operation is idempotent.
+    #
+    # Any errors raised in the build process are re-raised. Artifacts
+    # that fail to build successfully are purged.
+    #
+    # @param signature [ReleaseSignature]
+    # @param plan [Class] The class, which should be Plan::Plan
+    # @return [Artifact] The built artifact
+    def for(signature, plan)
+      cleanup!
+
+      artifact = artifact_for(signature)
+      unless artifact.path.exist?
+        artifact.path.mkpath
+        plan.new(artifact).call
+      end
+
+      artifact
+    rescue StandardError
+      FileUtils.remove_entry_secure(artifact.path)
+      raise
+    end
+
+    private
+
+    attr_reader :dir, :max_cache
+
+    def cleanup!
+      cached_dirs
+        .sort_by(&:mtime)
+        .slice(0, [0, cached_dirs.count - max_cache].max)
+        .each {|cache| FileUtils.remove_entry_secure(cache) }
+    end
+
+    def cached_dirs
+      dir.children.select(&:directory?)
+    end
+
+    def artifact_for(signature)
+      Artifact.new(
+        path: path_for(signature),
+        signature: signature
+      )
+    end
+
+    def dir_for(signature)
+      [:source, :shared, :unshared]
+        .map {|method| signature.public_send(method) }
+        .map(&:commitish)
+        .map {|sha| sha.slice(0, 7) }
+        .join("-")
+    end
+
+    def path_for(signature)
+      dir/dir_for(signature)
+    end
+
+  end
+
+end

--- a/lib/moku/deploy_config.rb
+++ b/lib/moku/deploy_config.rb
@@ -37,6 +37,10 @@ module Moku
       from_dir(ref_repo.resolve(ref))
     end
 
+    # @param deploy_dir [Pathname]
+    # @param env [Hash<Symbol, String>]
+    # @param systemd_services [Array<String>]
+    # @param sites [Sites]
     def initialize(deploy_dir:, env:, systemd_services:, sites:)
       @deploy_dir = Pathname.new(deploy_dir).expand_path(Moku.root)
       @env = env

--- a/lib/moku/pipeline/deploy.rb
+++ b/lib/moku/pipeline/deploy.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "moku/artifact"
 require "moku/deploy_config"
 require "moku/logged_release"
 require "moku/pipeline/pipeline"
@@ -30,10 +29,9 @@ module Moku
 
       private
 
-      attr_reader :build_dir, :reference, :signature, :artifact, :release
+      attr_reader :reference, :signature, :artifact, :release
 
       def init
-        @build_dir = Pathname.new(Dir.mktmpdir)
         @reference = command.reference
       end
 
@@ -42,8 +40,7 @@ module Moku
       end
 
       def build_artifact
-        @artifact = Artifact.new(path: build_dir, signature: signature)
-        Plan::BasicBuild.new(artifact).call
+        @artifact = Moku.artifact_repo.for(signature, Plan::BasicBuild)
       end
 
       def deploy_release

--- a/lib/moku/sequence.rb
+++ b/lib/moku/sequence.rb
@@ -13,6 +13,9 @@ module Moku
     # either the collection is exhausted or one of the items returns a failing
     # Status object. If no failures are encountered, this returns a successful
     # Status object. Otherwise, it returns the failed status object.
+    #
+    # @example Pass a release to each task's #call method
+    #   Sequence.do(tasks, release)
     def self.do(items, *args)
       items.reduce(Status.success) do |last_result, item|
         break(last_result) unless last_result.success?
@@ -25,6 +28,14 @@ module Moku
     # either the collection is exhausted or one of the items returns a failing
     # Status object. If no failures are encountered, this returns a successful
     # Status object. Otherwise, it returns a failed status object.
+    #
+    # Note that your block must return something that responds to #success?,
+    # such as a Status instance.
+    #
+    # @example
+    #   Sequence.for(commands) do |command|
+    #     runner.run(command)
+    #   end
     def self.for(items)
       items.reduce(OpenStruct.new(success?: true)) do |last_result, item|
         break(last_result) unless last_result.success?

--- a/lib/moku/sites/scope.rb
+++ b/lib/moku/sites/scope.rb
@@ -3,8 +3,7 @@
 module Moku
   class Sites
 
-    # Scopes are used to create an a list of hosts from a Sites
-    # object.
+    # Scopes are used to create a list of hosts from a Sites object.
     class Scope
 
       def self.all

--- a/lib/moku/task/create_structure.rb
+++ b/lib/moku/task/create_structure.rb
@@ -16,7 +16,7 @@ module Moku
 
       def command(release)
         "mkdir -p --mode=2775 #{release.deploy_path.parent} && " \
-          "mkdir --mode=2775 #{release.deploy_path}"
+          "mkdir -p --mode=2775 #{release.deploy_path}"
       end
     end
 

--- a/lib/moku/task/download_references.rb
+++ b/lib/moku/task/download_references.rb
@@ -25,6 +25,8 @@ module Moku
 
       attr_reader :ref_repo
 
+      # @param ref [ArchiveReference]
+      # @param path [Pathname] Where to install the files
       def add_reference(ref, path)
         ref_repo.resolve(ref)
           .cp(path)

--- a/spec/integration/deploy_spec.rb
+++ b/spec/integration/deploy_spec.rb
@@ -11,61 +11,59 @@ require "pathname"
 
 module Moku
 
-  RSpec.describe "deploy integration", integration: true do
-    describe "deploy" do
-      context "without rails" do
-        include_context "with a sandbox", "test-norails"
-        include_context "with a deployed instance", "test-norails"
-        let(:gem) { "pry" }
-        let(:development_gem) { "faker" }
-        let(:test_gem) { "rspec" }
-        let(:source) { Pathname.new("some_source_file.txt") }
+  RSpec.describe "integration deploy", integration: true do
+    context "without rails" do
+      include_context "with a sandbox", "test-norails"
+      include_context "with a deployed instance", "test-norails"
+      let(:gem) { "pry" }
+      let(:development_gem) { "faker" }
+      let(:test_gem) { "rspec" }
+      let(:source) { Pathname.new("some_source_file.txt") }
 
-        it_behaves_like "a successful deploy"
+      it_behaves_like "a successful deploy"
 
-        it "doesn't install development gems" do
-          within(current_dir) do |env|
-            expect(`#{env} bundle list`).not_to match(/#{development_gem}/)
-          end
-        end
-
-        it "doesn't install test gems" do
-          within(current_dir) do |env|
-            expect(`#{env} bundle list`).not_to match(/#{test_gem}/)
-          end
+      it "doesn't install development gems" do
+        within(current_dir) do |env|
+          expect(`#{env} bundle list`).not_to match(/#{development_gem}/)
         end
       end
 
-      context "with rails" do
-        include_context "with a sandbox", "test-rails"
-        include_context "with a deployed instance", "test-rails"
-        let(:gem) { "rails" }
-        let(:source) { Pathname.new("config/environment.rb") }
-
-        it_behaves_like "a successful deploy"
-
-        it "current/public/assets 2775" do
-          expect(current_dir/"public"/"assets").to have_permissions("2775")
+      it "doesn't install test gems" do
+        within(current_dir) do |env|
+          expect(`#{env} bundle list`).not_to match(/#{test_gem}/)
         end
+      end
+    end
 
-        it "current/bin/rails 6770" do
-          expect(current_dir/"bin"/"rails").to have_permissions("6770")
-        end
+    context "with rails" do
+      include_context "with a sandbox", "test-rails"
+      include_context "with a deployed instance", "test-rails"
+      let(:gem) { "rails" }
+      let(:source) { Pathname.new("config/environment.rb") }
 
-        it "runs the migrations" do
-          expect(`sqlite3 #{current_dir/"db"/"production.sqlite3"} ".schema posts"`.chomp)
-            .to match(/CREATE TABLE (IF NOT EXISTS )?"posts"/)
-          expect(`sqlite3 #{current_dir/"db"/"production.sqlite3"} ".schema things"`.chomp)
-            .to match(/CREATE TABLE (IF NOT EXISTS )?"things"/)
-        end
+      it_behaves_like "a successful deploy"
 
-        it "installs a working project" do
-          within(current_dir) do |env|
-            _, _, status = Open3.capture3(
-              "#{env} bin/rails runner -e production 'Post.new.valid?'"
-            )
-            expect(status.success?).to be true
-          end
+      it "current/public/assets 2775" do
+        expect(current_dir/"public"/"assets").to have_permissions("2775")
+      end
+
+      it "current/bin/rails 6770" do
+        expect(current_dir/"bin"/"rails").to have_permissions("6770")
+      end
+
+      it "runs the migrations" do
+        expect(`sqlite3 #{current_dir/"db"/"production.sqlite3"} ".schema posts"`.chomp)
+          .to match(/CREATE TABLE (IF NOT EXISTS )?"posts"/)
+        expect(`sqlite3 #{current_dir/"db"/"production.sqlite3"} ".schema things"`.chomp)
+          .to match(/CREATE TABLE (IF NOT EXISTS )?"things"/)
+      end
+
+      it "installs a working project" do
+        within(current_dir) do |env|
+          _, _, status = Open3.capture3(
+            "#{env} bin/rails runner -e production 'Post.new.valid?'"
+          )
+          expect(status.success?).to be true
         end
       end
     end

--- a/spec/integration/releases_spec.rb
+++ b/spec/integration/releases_spec.rb
@@ -8,7 +8,7 @@ require "moku/command/rollback"
 
 module Moku
 
-  RSpec.describe "releases integration", integration: true do
+  RSpec.describe "integration releases", integration: true do
     include_context "with a sandbox", "test-norails"
     include_context "with a deployed instance", "test-norails"
     include_context "with a deployed instance", "test-norails"

--- a/spec/support/with_a_sandbox.rb
+++ b/spec/support/with_a_sandbox.rb
@@ -34,6 +34,7 @@ module Moku
         config.register(:test_run_root) { Moku.root/"sandbox" }
         config.register(:fixtures_root) { Moku.root/"spec"/"fixtures"/"integration" }
         config.register(:deploy_root) {|c| c.test_run_root/"deploy" }
+        config.register(:build_root) {|c| c.test_run_root/"builds" }
 
         # Configure the application
         config.register(:user) { ENV["USER"] }


### PR DESCRIPTION
* Adds branches_root to settings.yml
* No longer build artifacts in temp
* Add ArtifactRepo
* Avoid rebuilding successfully built artifacts, as identified by signature
* Purge artifacts beyond some limit (to avoid filling up disk)