### PR TITLE
Cache artifacts and avoid building artifacts in the system temp dir

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,7 @@ instance_root: data/instances
 bundle_cache_path: data/bundle_cache
 releases_root: releases
 deployer_env_root: deploy/capfiles
+build_root: data/cache/builds
 ref_root: data/cache/references
 split_token: 1239810_moku_split_token_678303
 shared_name: infrastructure
@@ -13,3 +14,4 @@ finish_deploy_filename: finish_deploy.yml
 deploy_config_filename: deploy.yml
 release_time_format: "%Y%m%d%H%M%S%L"
 ref_cache_max: 10
+build_cache_max: 20

--- a/lib/moku.rb
+++ b/lib/moku.rb
@@ -3,6 +3,7 @@
 require "moku/version"
 require "moku/archive_reference"
 require "moku/artifact"
+require "moku/artifact_repo"
 require "moku/auth_service"
 require "moku/cached_bundle"
 require "moku/cli"
@@ -54,6 +55,7 @@ module Moku
             filesystem: c.filesystem
           )
         end
+        container.register(:artifact_repo) {|c| Moku::ArtifactRepo.new(c.build_root) }
         container.register(:ref_repo) do |c|
           Moku::ReferenceRepo.new(
             c.ref_root,
@@ -89,20 +91,17 @@ module Moku
         end
 
         container.register(:invoker) { Moku::Invoker.new }
-        container.register(:instance_root) do
-          Pathname.new(settings.instance_root).expand_path(Moku.root)
-        end
-        container.register(:releases_root) do
-          Pathname.new(settings.releases_root).expand_path(Moku.root)
-        end
-        container.register(:deployer_env_root) do
-          Pathname.new(settings.deployer_env_root).expand_path(Moku.root)
-        end
-        container.register(:ref_root) do
-          Pathname.new(settings.ref_root).expand_path(Moku.root)
-        end
-        container.register(:branches_root) do
-          Pathname.new(settings.branches_root).expand_path(Moku.root)
+        [
+          :instance_root,
+          :releases_root,
+          :deployer_env_root,
+          :ref_root,
+          :branches_root,
+          :build_root
+        ].each do |root|
+          container.register(root) do
+            Pathname.new(settings.public_send(root)).expand_path(Moku.root)
+          end
         end
       end
     end

--- a/lib/moku/artifact_repo.rb
+++ b/lib/moku/artifact_repo.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "moku/artifact"
+require "pathname"
+require "fileutils"
+
+module Moku
+
+  # Repository for built artifacts
+  class ArtifactRepo
+
+    # @param dir [Pathname] A directory in which to store artifacts
+    def initialize(dir, max_cache: Moku.build_cache_max)
+      @dir = Pathname.new(dir).tap(&:mkpath)
+      @max_cache = (max_cache - 1) || 1
+      # -1 because we prune before building, so we won't reach it until max + 1.
+    end
+
+    # Obtain the build for the given instance and signature, and build
+    # it using the given plan if it is not already built.
+    # This operation is idempotent.
+    #
+    # Any errors raised in the build process are re-raised. Artifacts
+    # that fail to build successfully are purged.
+    #
+    # @param signature [ReleaseSignature]
+    # @param plan [Class] The class, which should be Plan::Plan
+    # @return [Artifact] The built artifact
+    def for(signature, plan)
+      cleanup!
+
+      artifact = artifact_for(signature)
+      unless artifact.path.exist?
+        artifact.path.mkpath
+        plan.new(artifact).call
+      end
+
+      artifact
+    rescue StandardError
+      FileUtils.remove_entry_secure(artifact.path)
+      raise
+    end
+
+    private
+
+    attr_reader :dir, :max_cache
+
+    def cleanup!
+      cached_dirs
+        .sort_by(&:mtime)
+        .slice(0, [0, cached_dirs.count - max_cache].max)
+        .each {|cache| FileUtils.remove_entry_secure(cache) }
+    end
+
+    def cached_dirs
+      dir.children.select(&:directory?)
+    end
+
+    def artifact_for(signature)
+      Artifact.new(
+        path: path_for(signature),
+        signature: signature
+      )
+    end
+
+    def dir_for(signature)
+      [:source, :shared, :unshared]
+        .map {|method| signature.public_send(method) }
+        .map(&:commitish)
+        .map {|sha| sha.slice(0, 7) }
+        .join("-")
+    end
+
+    def path_for(signature)
+      dir/dir_for(signature)
+    end
+
+  end
+
+end

--- a/lib/moku/pipeline/deploy.rb
+++ b/lib/moku/pipeline/deploy.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "moku/artifact"
 require "moku/deploy_config"
 require "moku/logged_release"
 require "moku/pipeline/pipeline"
@@ -30,10 +29,9 @@ module Moku
 
       private
 
-      attr_reader :build_dir, :reference, :signature, :artifact, :release
+      attr_reader :reference, :signature, :artifact, :release
 
       def init
-        @build_dir = Pathname.new(Dir.mktmpdir)
         @reference = command.reference
       end
 
@@ -42,8 +40,7 @@ module Moku
       end
 
       def build_artifact
-        @artifact = Artifact.new(path: build_dir, signature: signature)
-        Plan::BasicBuild.new(artifact).call
+        @artifact = Moku.artifact_repo.for(signature, Plan::BasicBuild)
       end
 
       def deploy_release

--- a/spec/support/with_a_sandbox.rb
+++ b/spec/support/with_a_sandbox.rb
@@ -34,6 +34,7 @@ module Moku
         config.register(:test_run_root) { Moku.root/"sandbox" }
         config.register(:fixtures_root) { Moku.root/"spec"/"fixtures"/"integration" }
         config.register(:deploy_root) {|c| c.test_run_root/"deploy" }
+        config.register(:build_root) {|c| c.test_run_root/"builds" }
 
         # Configure the application
         config.register(:user) { ENV["USER"] }


### PR DESCRIPTION
* Adds branches_root to settings.yml
* No longer build artifacts in temp
* Add ArtifactRepo
* Avoid rebuilding successfully built artifacts, as identified by
  signature
* Purge artifacts beyond some limit (to avoid filling up disk)