### PR TITLE
Enable in systemd on deploy

### DIFF
--- a/lib/moku/plan/basic_deploy.rb
+++ b/lib/moku/plan/basic_deploy.rb
@@ -3,9 +3,9 @@
 require "moku/plan/plan"
 require "moku/task_file"
 require "moku/task/create_structure"
+require "moku/task/enable"
 require "moku/task/overlay_sites"
 require "moku/task/remote_shell"
-require "moku/task/restart"
 require "moku/task/set_current"
 require "moku/task/upload"
 
@@ -32,7 +32,10 @@ module Moku
       end
 
       def finish
-        [Task::SetCurrent.new]
+        [
+          Task::SetCurrent.new,
+          Task::Enable.new
+        ]
       end
 
       private

--- a/lib/moku/task/enable.rb
+++ b/lib/moku/task/enable.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "moku/task/task"
+require "moku/sequence"
+require "moku/sites/scope"
+
+module Moku
+  module Task
+
+    # Enable the release's systemd services on the target hosts.
+    class Enable < Task
+      def call(release)
+        Sequence.for(release.systemd_services) do |service|
+          release.run(Sites::Scope.all, "sudo systemctl enable #{service}")
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Resolves AEIM-1161

* Adds Task::Enable, which enables an instance's systemd services
* Adds Task::Enable to Plan::BasicDeploy#finish

There were a couple sensible locations to put this task.