### PR TITLE
Revert "Remove Release#rbenv_env use in Release#run"

### DIFF
--- a/lib/moku/release.rb
+++ b/lib/moku/release.rb
@@ -49,11 +49,18 @@ module Moku
 
     attr_reader :artifact, :deploy_config, :remote_runner, :release_dir
 
+    # Environment manipulation necessary to adopt the rbenv version of the
+    # source to be installed. This only has an effect in the test environment
+    # and development enviroments.
+    def rbenv_env
+      "PATH=$RBENV_ROOT/versions/$(rbenv local)/bin:$PATH"
+    end
+
     def contextualize(command)
       "if [ -d #{deploy_path} ]; " \
         "then cd #{deploy_path}; " \
         "fi; " \
-        "#{deploy_config.shell_env} #{command}"
+        "#{rbenv_env} #{deploy_config.shell_env} #{command}"
     end
 
     def run_on_hosts(hosts, command)


### PR DESCRIPTION
This reverts commit 0b101367d1aea0f80d550373086b772e86b7044d.

I had originally removed this code as it seemed to no longer be
necessary. That determination was premature.

Even now, I seem to only need this some of the time.