### PR TITLE
Cleanup caches with just one command

### DIFF
--- a/lib/moku/pipeline/deploy.rb
+++ b/lib/moku/pipeline/deploy.rb
@@ -74,12 +74,10 @@ module Moku
       end
 
       def cleanup_caches
-        Sequence.for(instance.releases - instance.caches) do |logged_release|
-          release.run(
-            Sites::Scope.all,
-            "rm -rf #{release.releases_path/logged_release.id}"
-          )
-        end
+        exclude_caches = instance.caches.map {|cache| "grep -v #{cache.id}" }.join(" | ")
+        cmd = "cd #{release.releases_path} && " \
+          "ls -1 #{release.releases_path} | #{exclude_caches} | xargs rm -rf"
+        release.run(Sites::Scope.all, cmd)
       end
 
     end


### PR DESCRIPTION
Resolves AEIM-1834

I tested this manually by populating the releases directory then letting the normal processes run. I could create a test that does the same if the reviewer thinks it is necessary. That would require expanding the test harness significantly. I don't expect `cleanup_caches` to change any time soon.