### PR TITLE
Fail fast when command line arguments are missing

### DIFF
--- a/lib/moku/cli.rb
+++ b/lib/moku/cli.rb
@@ -17,6 +17,8 @@ module Moku
       program_desc "A deployment tool"
       version Moku::VERSION
       synopsis_format :terminal
+      subcommand_option_handling(:normal)
+      arguments(:strict)
 
       accept(Hash) do |value|
         value.split(",").map do |pair|


### PR DESCRIPTION
Resolves AEIM-1900

Enables GLI's strict argument checking and subcommand option
namespacing. The latter doesn't affect us, but is required by
the former.

Since there are no tests that exercise the cli, we need to test this by hand. Or say yolo.