### PR TITLE
Require pinning to major.minor ruby version

### DIFF
--- a/lib/moku/plan/basic_build.rb
+++ b/lib/moku/plan/basic_build.rb
@@ -2,10 +2,11 @@
 
 require "moku/plan/plan"
 require "moku/task_file"
+require "moku/task/build_permissions"
 require "moku/task/bundle"
 require "moku/task/download_references"
-require "moku/task/build_permissions"
 require "moku/task/shell"
+require "moku/task/validate_pin"
 
 module Moku
   module Plan
@@ -21,6 +22,7 @@ module Moku
       def main
         [
           Task::DownloadReferences.new,
+          Task::ValidatePin.new,
           Task::Bundle.new
         ]
       end

--- a/lib/moku/task/validate_pin.rb
+++ b/lib/moku/task/validate_pin.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "moku/task/task"
+require "moku/status"
+require "moku/validator/gemfile"
+require "moku/validator/ruby_version"
+
+module Moku
+  module Task
+
+    # Validates that the project correctly specifies its ruby version
+    # * There is a .ruby-version present
+    # * It specifies only a major version (e.g. 2.5)
+    # * If the Gemfile includes a 'ruby' directive, it should specify only a major version.
+    class ValidatePin
+
+      def initialize
+        @errors = []
+      end
+
+      # @param artifact [Artifact]
+      # @return [Status]
+      def call(artifact)
+        @errors += Validator::Gemfile.new(artifact).errors
+        @errors += Validator::RubyVersion.new(artifact).errors
+        if errors.empty?
+          Status.success
+        else
+          Status.failure(errors.join("\n"))
+        end
+      end
+
+      private
+
+      attr_reader :errors
+
+    end
+
+  end
+end

--- a/lib/moku/validator/gemfile.rb
+++ b/lib/moku/validator/gemfile.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "moku/validator/validator"
+
+module Moku
+  module Validator
+
+    # Validate's an artifact's Gemfile. Specifically:
+    # * If the Gemfile includes a 'ruby' directive, it should specify
+    #   only a major version (e.g. 2.5).
+    class Gemfile < Validator
+      GEMFILE_MALFORMED = "When specifying the ruby version in the Gemfile, the" \
+        " optional ruby directive must specify exactly MAJOR.MINOR version."
+      GEMFILE_FORM = /^ruby "[1-9]\.[0-9]+"$/ # rubocop:disable Style/MutableConstant
+
+      def validate
+        if path.exist?
+          directive = File.open(path).grep(/^ruby/)
+          unless directive.empty?
+            unless directive.first =~ GEMFILE_FORM
+              @errors << GEMFILE_MALFORMED
+            end
+          end
+        end
+      end
+
+      private
+
+      alias_method :artifact, :target
+
+      def path
+        @path ||= artifact.path/"Gemfile"
+      end
+    end
+
+  end
+end

--- a/lib/moku/validator/ruby_version.rb
+++ b/lib/moku/validator/ruby_version.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "moku/validator/validator"
+
+module Moku
+  module Validator
+
+    # Validate an artifact's .ruby-version file. Specifically:
+    # * There is a .ruby-version present
+    # * It specifies only a major version (e.g. 2.5)
+    class RubyVersion < Validator
+      VERSION_FORM = /^[1-9]\.[0-9]+$/ # rubocop:disable Style/MutableConstant
+      VERSION_MALFORMED = "A forbidden .ruby-version file was found. The .ruby-version" \
+        " file must specify exactly MAJOR.MINOR version."
+      VERSION_MISSING = "You must supply a .ruby-version file that specifies exactly" \
+        " the MAJOR.MINOR version."
+
+      def validate
+        if path.exist?
+          unless VERSION_FORM =~ File.read(path)
+            @errors << VERSION_MALFORMED
+          end
+        else
+          @errors << VERSION_MISSING
+        end
+      end
+
+      private
+
+      alias_method :artifact, :target
+
+      def path
+        @path ||= artifact.path/".ruby-version"
+      end
+    end
+
+  end
+end

--- a/lib/moku/validator/validator.rb
+++ b/lib/moku/validator/validator.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Moku
+  module Validator
+
+    # Perform a set of validations on an artifact or release
+    class Validator
+      def initialize(target)
+        @target = target
+        @errors = []
+      end
+
+      def errors
+        validate
+        @errors
+      end
+
+      def valid?
+        validate
+        errors.empty?
+      end
+
+      private
+
+      attr_reader :target
+    end
+
+  end
+end

--- a/spec/task/validate_pin_spec.rb
+++ b/spec/task/validate_pin_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+require "moku/task/validate_pin"
+
+# Note that Task::ValidatePin's direct dependencies are not under test. If
+# those validators are extracted, they will need their own tests.
+module Moku
+  RSpec.describe Task::ValidatePin do
+    include FakeFS::SpecHelpers
+    let(:path) { Pathname.new("/some/path") }
+    let(:artifact) { double(:artifact, path: path) }
+    let(:task) { described_class.new }
+    let(:status) { task.call(artifact) }
+
+    before(:each) do
+      FileUtils.mkdir_p path.to_s
+      allow(artifact).to receive(:with_env).and_yield
+    end
+
+    context "without a .ruby-version file" do
+      it { expect(status.success?).to be false }
+      it "reports the issue" do
+        expect(status.error).to match(/must supply a \.ruby-version file/)
+      end
+    end
+
+    context "with an empty .ruby-version file" do
+      before(:each) { File.write(path/".ruby-version", "") }
+
+      it { expect(status.success?).to be false }
+      it "reports the issue" do
+        expect(status.error)
+          .to match(/.ruby-version file must specify exactly MAJOR\.MINOR version/)
+      end
+    end
+
+    context "with a .ruby-version file that specifies x.y.z version" do
+      before(:each) { File.write(path/".ruby-version", "2.5.3") }
+
+      it { expect(status.success?).to be false }
+      it "reports the issue" do
+        expect(status.error)
+          .to match(/.ruby-version file must specify exactly MAJOR\.MINOR version/)
+      end
+    end
+
+    context "with a .ruby-version file that specifies x.y version" do
+      before(:each) { File.write(path/".ruby-version", "2.5") }
+
+      context "without a Gemfile" do
+        it { expect(status.success?).to be true }
+      end
+
+      context "with a Gemfile w/o a ruby directive" do
+        before(:each) { File.write(path/"Gemfile", "") }
+
+        it { expect(status.success?).to be true }
+      end
+
+      context "with a Gemfile w/ a x.y.z ruby directive" do
+        before(:each) { File.write(path/"Gemfile", 'ruby "2.5.3"') }
+
+        it { expect(status.success?).to be false }
+        it "reports the issue" do
+          expect(status.error)
+            .to match(/ruby directive must specify exactly MAJOR\.MINOR version/)
+        end
+      end
+
+      context "with a Gemfile w/ a x.y ruby directive" do
+        before(:each) { File.write(path/"Gemfile", 'ruby "2.5"') }
+
+        it { expect(status.success?).to be true }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves AEIM-1704

This adds Task::ValidatePin to Plan::BasicBuild, it performs the following checks:
 * There is a .ruby-version present
 * It specifies only a major version (e.g. 2.5)
 * If the Gemfile includes a 'ruby' directive, it should specify only a major version.

Additionally, this adds:
* Validator::RubyVersion
* Validator::Gemfile

These two files do not have unit tests as they are currently
implementation details of Task::ValidatePin.