### PR TITLE
AEIM-2056 - Simplify permissions on the way to local disk

### DIFF
--- a/lib/moku/task/build_permissions.rb
+++ b/lib/moku/task/build_permissions.rb
@@ -67,15 +67,15 @@ module Moku
       private
 
       def private_permissions
-        @private_permissions ||= Permissions.new(bin: 0o6770, dir: 0o2775, file: 0o660)
+        @private_permissions ||= Permissions.new(bin: 0o0750, dir: 0o0755, file: 0o0640)
       end
 
       def public_permissions
-        @public_permissions ||= Permissions.new(bin: 0o6775, dir: 0o2775, file: 0o664)
+        @public_permissions ||= Permissions.new(bin: 0o0755, dir: 0o0755, file: 0o0644)
       end
 
       def sensitive_permissions
-        @sensitive_permissions ||= Permissions.new(bin: 0o6770, dir: 0o2770, file: 0o660)
+        @sensitive_permissions ||= Permissions.new(bin: 0o0750, dir: 0o0750, file: 0o0640)
       end
 
     end

--- a/lib/moku/task/create_structure.rb
+++ b/lib/moku/task/create_structure.rb
@@ -15,8 +15,8 @@ module Moku
       private
 
       def command(release)
-        "mkdir -p --mode=2775 #{release.deploy_path.parent} && " \
-          "mkdir -p --mode=2775 #{release.deploy_path}"
+        "mkdir -p --mode=755 #{release.deploy_path.parent} && " \
+          "mkdir -p --mode=755 #{release.deploy_path}"
       end
     end
 

--- a/spec/integration/deploy_spec.rb
+++ b/spec/integration/deploy_spec.rb
@@ -147,12 +147,12 @@ module Moku
       let(:current_dir) { deploy_dir/"current" }
 
       RSpec.shared_examples "a deployed rails project" do
-        it "current/public/assets 2775" do
-          expect(current_dir/"public"/"assets").to have_permissions("2775")
+        it "current/public/assets 755" do
+          expect(current_dir/"public"/"assets").to have_permissions("755")
         end
 
-        it "current/bin/rails 6770" do
-          expect(current_dir/"bin"/"rails").to have_permissions("6770")
+        it "current/bin/rails 750" do
+          expect(current_dir/"bin"/"rails").to have_permissions("750")
         end
 
         it "installs a working project" do

--- a/spec/support/a_successful_deploy.rb
+++ b/spec/support/a_successful_deploy.rb
@@ -33,27 +33,27 @@ module Moku
     end
 
     describe "permissions" do
-      it "releases 2775" do
-        expect(deploy_dir/"releases").to have_permissions("2775")
+      it "releases 755" do
+        expect(deploy_dir/"releases").to have_permissions("755")
       end
-      it "releases/<release> 2775" do
+      it "releases/<release> 755" do
         release_dir = (deploy_dir/"releases").children.first
-        expect(release_dir).to have_permissions("2775")
+        expect(release_dir).to have_permissions("755")
       end
-      it "current/public 2775" do
-        expect(current_dir/"public").to have_permissions("2775")
+      it "current/public 755" do
+        expect(current_dir/"public").to have_permissions("755")
       end
-      it "current/public/<file> 664" do
+      it "current/public/<file> 644" do
         file = (current_dir/"public").children.find(&:file?)
-        expect(file).to have_permissions("664")
+        expect(file).to have_permissions("644")
       end
-      it "current/<some_dev> 660" do
+      it "current/<some_dev> 640" do
         file = current_dir/"some"/"dev"/"file.txt"
-        expect(file).to have_permissions("660")
+        expect(file).to have_permissions("640")
       end
-      it "current/<some_infrastructure> 660" do
+      it "current/<some_infrastructure> 640" do
         file = current_dir/"some"/"infrastructure"/"file.txt"
-        expect(file).to have_permissions("660")
+        expect(file).to have_permissions("640")
       end
     end
 


### PR DESCRIPTION
We're working toward accommodating local-disk-only deployments with no
human users on the servers. This simplifies the file modes to some
degree and corresponds to a puppet provisioning change to support the
app user's home directory being the deployment target.

There is an open question of whether these modes are exactly right.
Specifically, is 740 right for binaries, or should they be 750?