### PR TITLE
AEIM-2033 Symlink paths from infrastructure.yml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,6 @@ PATH
       canister
       ettin (~> 1.2.1)
       gli
-      rsync
       terminal-table
 
 GEM
@@ -52,7 +51,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rsync (1.0.9)
     rubocop (0.67.2)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)

--- a/lib/moku.rb
+++ b/lib/moku.rb
@@ -22,6 +22,7 @@ require "moku/release_signature"
 require "moku/scm/git"
 require "moku/shell/basic"
 require "moku/shell/passthrough"
+require "moku/shell/remote_release"
 require "moku/shell/secure_remote"
 require "moku/upload"
 
@@ -55,6 +56,9 @@ module Moku
             c.ref_root,
             c.git_runner
           )
+        end
+        container.register(:remote_context) do |c|
+          Shell::RemoteRelease::Builder.new(remote_runner: c.remote_runner)
         end
         container.register(:instance_repo) do |c|
           Moku::FileInstanceRepo.new(

--- a/lib/moku/deploy_config.rb
+++ b/lib/moku/deploy_config.rb
@@ -3,7 +3,6 @@
 require "core_extensions/hash/keys"
 require "moku/sites"
 require "pathname"
-require "shellwords"
 require "yaml"
 
 module Moku
@@ -49,24 +48,13 @@ module Moku
       @sites = sites
     end
 
-    attr_reader :deploy_dir, :sites, :systemd_services
-
-    def shell_env
-      @shell_env ||= env.keep_if {|_key, value| value }
-        .map {|key, value| "#{key.to_s.upcase}=#{Shellwords.escape(value)}" }
-        .join(" ")
-    end
+    attr_reader :deploy_dir, :sites, :systemd_services, :env
 
     def eql?(other)
       deploy_dir == other.deploy_dir &&
         systemd_services == other.systemd_services &&
-        sites.hosts == other.sites.hosts &&
-        shell_env == other.shell_env
+        sites.hosts == other.sites.hosts
     end
-
-    private
-
-    attr_reader :env
 
   end
 end

--- a/lib/moku/plan/basic_deploy.rb
+++ b/lib/moku/plan/basic_deploy.rb
@@ -7,6 +7,7 @@ require "moku/task/enable"
 require "moku/task/overlay_sites"
 require "moku/task/remote_shell"
 require "moku/task/set_current"
+require "moku/task/symlink"
 require "moku/task/upload"
 
 module Moku
@@ -21,7 +22,8 @@ module Moku
         [
           Task::CreateStructure.new,
           Task::Upload.new,
-          Task::OverlaySites.new
+          Task::OverlaySites.new,
+          Task::Symlink.new
         ]
       end
 

--- a/lib/moku/release.rb
+++ b/lib/moku/release.rb
@@ -1,30 +1,24 @@
 # frozen_string_literal: true
 
-require "moku/artifact"
-require "moku/bundleable"
-require "moku/sequence"
-
 module Moku
 
   # Uniquely identifies a deployed instance at a point in time. All deployment
   # operations first create a release, and then attempt to deploy it.
   class Release
     extend Forwardable
-    include Bundleable
 
     # @param artifact [Artifact]
     # @param deploy_config [DeployConfig]
-    def initialize(artifact:, deploy_config:, remote_runner: nil, release_dir: nil)
+    def initialize(artifact:, deploy_config:, release_dir: nil)
       @artifact = artifact
       @deploy_config = deploy_config
-      @remote_runner = remote_runner || Moku.remote_runner
       @id = Time.now.strftime(Moku.release_time_format)
       @release_dir = release_dir || id
     end
 
     attr_reader :id
     def_delegators :@artifact, :path
-    def_delegators :@deploy_config, :systemd_services, :sites
+    def_delegators :@deploy_config, :systemd_services, :sites, :env
 
     # Absolute path to the directory where all releases are stored
     def releases_path
@@ -45,39 +39,12 @@ module Moku
     # @param scope [Sites::Scope]
     # @param command [String]
     def run(scope, command)
-      run_on_hosts(
-        scope.apply(deploy_config.sites),
-        command
-      )
+      Moku.remote_context.for(self).run(scope, command)
     end
 
     private
 
-    attr_reader :artifact, :deploy_config, :remote_runner, :release_dir
-
-    # Environment manipulation necessary to adopt the rbenv version of the
-    # source to be installed. This only has an effect in the test environment
-    # and development enviroments.
-    def rbenv_env
-      "PATH=$RBENV_ROOT/versions/$(rbenv local)/bin:$PATH"
-    end
-
-    def contextualize(command)
-      "if [ -d #{deploy_path} ]; " \
-        "then cd #{deploy_path}; " \
-        "fi; " \
-        "#{rbenv_env} #{deploy_config.shell_env} #{command}"
-    end
-
-    def run_on_hosts(hosts, command)
-      Sequence.for(hosts) do |host|
-        remote_runner.run(
-          user: host.user,
-          host: host.hostname,
-          command: contextualize(command)
-        )
-      end
-    end
+    attr_reader :artifact, :deploy_config, :release_dir
 
   end
 end

--- a/lib/moku/shell/remote_release.rb
+++ b/lib/moku/shell/remote_release.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "moku/sequence"
+require "shellwords"
+
+module Moku
+  module Shell
+
+    # A shell that executes remote commands for a release
+    class RemoteRelease
+
+      # Utility class to build RemoteRelease instances
+      class Builder
+        def initialize(remote_runner:)
+          @remote_runner = remote_runner
+        end
+
+        def for(release)
+          RemoteRelease.new(
+            sites: release.sites,
+            deploy_path: release.deploy_path,
+            env: release.env,
+            remote_runner: remote_runner
+          )
+        end
+
+        private
+
+        attr_reader :remote_runner
+      end
+
+      def initialize(sites:, deploy_path:, env:, remote_runner:)
+        @sites = sites
+        @deploy_path = deploy_path
+        @env = env
+        @remote_runner = remote_runner
+      end
+
+      def run(scope, command)
+        run_on_hosts(scope.apply(sites), command)
+      end
+
+      private
+
+      attr_reader :sites, :deploy_path, :env, :remote_runner
+
+      def shell_env
+        env.keep_if {|_key, value| value }
+          .map {|key, value| "#{key.to_s.upcase}=#{Shellwords.escape(value)}" }
+          .join(" ")
+      end
+
+      # Environment manipulation necessary to adopt the rbenv version of the
+      # source to be installed. This only has an effect in the test environment
+      # and development enviroments.
+      def rbenv_env
+        "PATH=$RBENV_ROOT/versions/$(rbenv local)/bin:$PATH"
+      end
+
+      def contextualize(command)
+        "if [ -d #{deploy_path} ]; " \
+          "then cd #{deploy_path}; " \
+          "fi; " \
+          "#{rbenv_env} #{shell_env} #{command}"
+      end
+
+      def run_on_hosts(hosts, command)
+        Sequence.for(hosts) do |host|
+          remote_runner.run(
+            user: host.user,
+            host: host.hostname,
+            command: contextualize(command)
+          )
+        end
+      end
+
+    end
+
+  end
+end

--- a/lib/moku/task/symlink.rb
+++ b/lib/moku/task/symlink.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "moku/task/task"
+require "moku/sites/scope"
+
+module Moku
+  module Task
+
+    # Create a symlink for eac path pair defined in infrastructure.yml
+    class Symlink < Task
+
+      def call(release)
+        release.run(Sites::Scope.all, command)
+      end
+
+      private
+
+      def command
+        <<~'CMD'
+          ruby -e 'require "yaml"; YAML.load_file("infrastructure.yml")["path"].each{|k,v| `ln -s #{v} #{k}`} if File.exist?("infrastructure.yml")'
+        CMD
+      end
+
+    end
+
+  end
+end

--- a/moku.gemspec
+++ b/moku.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "canister"
   spec.add_runtime_dependency "ettin", "~> 1.2.1"
   spec.add_runtime_dependency "gli"
-  spec.add_runtime_dependency "rsync"
   spec.add_runtime_dependency "terminal-table"
 
   spec.add_development_dependency "bundler"

--- a/spec/deploy_config_spec.rb
+++ b/spec/deploy_config_spec.rb
@@ -77,13 +77,5 @@ module Moku
         expect(described_class.from_ref(ref, ref_repo)).to eql(deploy_config)
       end
     end
-
-    describe "#shell_env" do
-      let(:env) { { rack_env: "staging", "foo" => "bar" } }
-
-      it "renders the env shell readable" do
-        expect(deploy_config.shell_env).to eql("RACK_ENV=staging FOO=bar")
-      end
-    end
   end
 end

--- a/spec/fixtures/integration/repos/norails/infrastructure/sites/local_site/infrastructure.yml
+++ b/spec/fixtures/integration/repos/norails/infrastructure/sites/local_site/infrastructure.yml
@@ -1,0 +1,3 @@
+path:
+  tmp: "/tmp/test-norails"
+  data: "/data"

--- a/spec/integration/deploy_spec.rb
+++ b/spec/integration/deploy_spec.rb
@@ -45,6 +45,12 @@ module Moku
           expect(File.read(current_dir/"site"/"only"/"local.txt"))
             .to eql("this file is specific to this site\n")
         end
+
+        # Other sites have no infrastructure.yml, so will skip this
+        it "creates a symlink for each dir in infrastructure.yml's path stanza" do
+          expect((current_dir/"tmp").readlink).to eql(Pathname.new("/tmp/test-norails"))
+          expect((current_dir/"data").readlink).to eql(Pathname.new("/data"))
+        end
       end
 
       context "with host #1 at site #1" do
@@ -164,6 +170,10 @@ module Moku
             .to match(/CREATE TABLE (IF NOT EXISTS )?"posts"/)
           expect(`sqlite3 #{current_dir/"db"/"production.sqlite3"} ".schema things"`.chomp)
             .to match(/CREATE TABLE (IF NOT EXISTS )?"things"/)
+        end
+
+        it "skips creating a symlink when the directory already exists" do
+          expect((current_dir/"log").symlink?).to be false
         end
       end
 

--- a/spec/shell/remote_release_spec.rb
+++ b/spec/shell/remote_release_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+require "moku/shell/remote_release"
+require "moku/sites"
+
+module Moku
+
+  RSpec.describe Shell::RemoteRelease do
+    let(:remote_runner) { double(:remote_runner, run: double(:status, success?: true)) }
+    let(:scope) { double(:scope) }
+    let(:command) { "somecommand" }
+    let(:user) { "someuser" }
+    let(:deploy_path) { Pathname.new("/deploy/dir/releases/12345") }
+    let(:env) { { rack_env: "staging", "foo" => "bar" } }
+    let(:sites) do
+      Sites.for(
+        "user" => user,
+        "site1" => ["host1", "host2"],
+        "site2" => ["host3", "host4"]
+      )
+    end
+
+    let(:shell) do
+      described_class.new(
+        sites: sites,
+        deploy_path: deploy_path,
+        env: env,
+        remote_runner: remote_runner
+      )
+    end
+
+    describe "#run" do
+      before(:each) do
+        allow(scope).to receive(:apply).with(sites).and_return(sites.hosts)
+      end
+
+      it "runs the commands on the hosts defined by the scope" do
+        scope.apply(sites).each do |host|
+          expect(remote_runner).to receive(:run)
+            .with(
+              user: user,
+              host: host.hostname,
+              command: /RACK_ENV=staging FOO=bar #{command}/
+            )
+        end
+        shell.run(scope, command)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
I experimented with a couple strategies here, which are spelled out in the commit messages. 0bf399a is a byproduct of that effort, but I have chosen to include it here anyway. The strategy I went with was to more or less use brute force, as can be seen in `Task::Symlink`. 

I think the correct strategy is to obviate the need to create these symlinks during the release phase altogether. The reason we can do that in the build phase now is site-specific files have not yet been moved into position. This saves us some file IO, at the cost of complexity. I think the best thing to do would be to build multiple artifacts, one for each host, possibly via hardlinks, towards the end of the build phase after the most costly operations (bundle, asset compilation) have been performed.