### PR TITLE
AEIM-2033 - Work around nested single quotes

### DIFF
--- a/lib/moku/task/symlink.rb
+++ b/lib/moku/task/symlink.rb
@@ -17,7 +17,7 @@ module Moku
 
       def command
         <<~'CMD'
-          ruby -e 'require "yaml"; YAML.load_file("infrastructure.yml")["path"].each{|k,v| `ln -s #{v} #{k}`} if File.exist?("infrastructure.yml")'
+          ruby -e "require %{yaml}; YAML.load_file(%{infrastructure.yml})[%{path}].each{|k,v| `ln -s #{v} #{k}`} if File.exist?(%{infrastructure.yml})"
         CMD
       end
 


### PR DESCRIPTION
Commands to be issued under bash over ssh are single quoted. The
original ruby command to make the symlinks was single quoted and
conflicted with this. This doesn't solve the larger challenge, but
changes the outer ruby -e single quotes to doubles and uses alternate
quotes in the expression to avoid needing any singles.