### PR TITLE
AEIM-2033 - Use base64 encoding in remote runners

### DIFF
--- a/lib/moku/shell/basic.rb
+++ b/lib/moku/shell/basic.rb
@@ -10,9 +10,12 @@ module Moku
     class Basic
 
       # Run the given command
+      # @param command [String] The command to run
+      # @param message [String] Optional message to be displayed. When this is not provided,
+      #   the full command is displayed.
       # @return [Status]
-      def run(command)
-        Moku.logger.debug(command)
+      def run(command, message = nil)
+        Moku.logger.debug(message || command)
         Bundler.with_clean_env do
           stdout, stderr, status = Open3.capture3(command)
           Status.new(status.success?, stdout, stderr)

--- a/lib/moku/shell/passthrough.rb
+++ b/lib/moku/shell/passthrough.rb
@@ -14,9 +14,13 @@ module Moku
         @stream = stream
       end
 
+      # Run the given command
+      # @param command [String] The command to run
+      # @param message [String] Optional message to be displayed. When this is not provided,
+      #   the full command is displayed.
       # @return [Status]
-      def run(command)
-        Moku.logger.debug(command)
+      def run(command, message = nil)
+        Moku.logger.debug(message || command)
         Bundler.with_clean_env do
           run_command(command)
         end

--- a/spec/integration/deploy_spec.rb
+++ b/spec/integration/deploy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "../spec_helper"
-require_relative "../support/fake_remote_runner"
 require_relative "../support/with_a_sandbox"
 require_relative "../support/with_a_deployed_instance"
 require_relative "../support/a_successful_deploy"

--- a/spec/support/realistic_remote_runner.rb
+++ b/spec/support/realistic_remote_runner.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "moku/shell/secure_remote"
+
+module Moku
+
+  # A version of SecureRemote that only connects to localhost, and modifies paths.
+  class RealisticRemoteRunner < Shell::SecureRemote
+    def ssh_options
+      @ssh_options ||= super.reject {|opt| opt.include?("-i") }
+    end
+
+    def run(host:, command:, user: :unused) # rubocop:disable Lint/UnusedMethodArgument
+      (Moku.deploy_root/host).mkpath
+      Dir.chdir(Moku.deploy_root/host) do |dir|
+        super(
+          host: "localhost",
+          command: command.gsub(/ \//, " #{dir}/"),
+          user: ENV["USER"]
+        )
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
* Changes Shell::SecureRemote to use base64 encoding, thus solving for
  whitespace and quotes in user-submitted commands.
* Adds the support class RealisticRemoteRunner, a subclass of
  Shell::SecureRemote that always connects to localhost as the current
  user, and also provides the path manipulation of FakeRemoteRunner.
* Uses the above when SSH=1 is passed to the integration tests.
* Adds the ability to pass an optional message to Shell::Basic#run and
  Shell::Passthrough#run, to be displayed instead of the command. This
  feature is used by Shell::SecureRemote to avoid displaying the command
  in its encoded form.