### PR TITLE
Strips the last newline from the command in Task::Symlink

### DIFF
--- a/lib/moku/task/symlink.rb
+++ b/lib/moku/task/symlink.rb
@@ -10,7 +10,7 @@ module Moku
     class Symlink < Task
 
       def call(release)
-        release.run(Sites::Scope.all, command)
+        release.run(Sites::Scope.all, command.strip)
       end
 
       private


### PR DESCRIPTION
This ensures there is no newline after the command.