### PR TITLE
revert submodule support

### DIFF
--- a/lib/moku/scm/git.rb
+++ b/lib/moku/scm/git.rb
@@ -39,7 +39,7 @@ module Moku
       # @return [WorkingDirectory]
       def safe_checkout(url, commitish, dir)
         cloned_dir = Pathname.new(dir)
-        system_runner.run("git clone --recurse-submodules #{url} #{cloned_dir}")
+        system_runner.run("git clone #{url} #{cloned_dir}")
         working_directory = Dir.chdir(cloned_dir) do
           system_runner.run("git checkout #{commitish}")
           build_working_dir(cloned_dir)
@@ -55,7 +55,7 @@ module Moku
 
       def build_working_dir(dir)
         files = Dir.chdir(dir) do
-          stdout = system_runner.run("git ls-files --recurse-submodules").output
+          stdout = system_runner.run("git ls-files").output
           stdout
             .split("\n")
             .map {|file| Pathname.new(file) }


### PR DESCRIPTION
This reverts two commits that aimed to support modules. The flags it uses are not available in the version of git from debian 8 (2.1).

Also, according to @botimer:

> We tried submodules and it basically didn't work
> It was there to support the chipmunk ui being in a separate repository.. I think we have two solutions to that scenario:
> 1. In the chipmunk case, I think combining the API and UI into one repository is probably better and easier (for dev and deployment)
> 2. In other yet-to-arrive cases, I think we can come up with a better multi-repo checkout model during the build. For example, maybe just adding build steps, or maybe adding something else to the instance config to do the total checkout "before" the build.

Thus, I propose reverting these flags so that we don't need to go to extra lengths to install a version of git on Debian 8 that supports this.



