### PR TITLE
Disable check that blocks teeny ruby version pinning

### DIFF
--- a/lib/moku/plan/basic_build.rb
+++ b/lib/moku/plan/basic_build.rb
@@ -22,7 +22,7 @@ module Moku
       def main
         [
           Task::DownloadReferences.new,
-          Task::ValidatePin.new,
+          # Task::ValidatePin.new,
           Task::Bundle.new
         ]
       end


### PR DESCRIPTION
minimum change to allow "teeny" pinned deployments