### PR TITLE
AE-9972 - Run bundle config set instead of --deployment

### DIFF
--- a/lib/moku/cached_bundle.rb
+++ b/lib/moku/cached_bundle.rb
@@ -23,7 +23,9 @@ module Moku
     def install(artifact)
       Sequence.for([
         "rsync -r #{cache_path(artifact)}/. #{artifact.bundle_path}/",
-        "bundle install --deployment '--without=development test'",
+        "bundle config set deployment 'true'",
+        "bundle config set without 'development test'",
+        "bundle install",
         "rsync -r #{artifact.bundle_path}/. #{cache_path(artifact)}/",
         "bundle clean"
       ]) {|command| artifact.run(command) }


### PR DESCRIPTION
Running `bundle install --deployment` is deprecated.