### PR TITLE
AE-9972 - Run bundle config commands with --local flag

### DIFF
--- a/lib/moku/cached_bundle.rb
+++ b/lib/moku/cached_bundle.rb
@@ -23,8 +23,8 @@ module Moku
     def install(artifact)
       Sequence.for([
         "rsync -r #{cache_path(artifact)}/. #{artifact.bundle_path}/",
-        "bundle config set deployment 'true'",
-        "bundle config set without 'development test'",
+        "bundle config set --local deployment 'true'",
+        "bundle config set --local without 'development test'",
         "bundle install",
         "rsync -r #{artifact.bundle_path}/. #{cache_path(artifact)}/",
         "bundle clean"


### PR DESCRIPTION
Without the --local flag, the settings default to the running user.
This was somehow causing the bundle clean to purge all of the gems,
rather than strictly anything unused from the cache.